### PR TITLE
Fix version_check property of swinfo.json

### DIFF
--- a/FFT/swinfo.json
+++ b/FFT/swinfo.json
@@ -5,7 +5,7 @@
   "description": "Fancy Fuel Tanks",
   "source": "https://github.com/cvusmo/FTT",
   "version": "0.1.0",
-  "version_check": "",
+  "version_check": "https://raw.githubusercontent.com/cvusmo/FFT/Master/FFT/swinfo.json",
   "dependencies": [
     {
       "id":  "SpaceWarp",


### PR DESCRIPTION
Hi @blacksheepcosmo,

`version_check` is supposed to point to an online copy of `swinfo.json` that can be checked for updates. Currently it's empty, but this pull request fixes it.

Noticed while working on KSP-CKAN/KSP2-NetKAN#75.

Cheers!
